### PR TITLE
Add settings shortcut and plugin metadata

### DIFF
--- a/includes/class-xefi-plugin.php
+++ b/includes/class-xefi-plugin.php
@@ -79,6 +79,10 @@ class Plugin {
         add_action( 'wp_head', [ $this, 'output_social_meta' ], 5 );
         add_action( 'admin_menu', [ $this, 'register_settings_page' ] );
         add_action( 'admin_init', [ $this, 'register_settings' ] );
+        add_filter(
+            'plugin_action_links_' . plugin_basename( XEFI_PLUGIN_FILE ),
+            [ $this, 'add_settings_link' ]
+        );
     }
 
     /**
@@ -545,6 +549,19 @@ class Plugin {
             'xefi-settings',
             [ $this, 'render_settings_page' ]
         );
+    }
+
+    /**
+     * Adds a settings shortcut to the Plugins listing.
+     */
+    public function add_settings_link( array $links ): array {
+        $url            = admin_url( 'options-general.php?page=xefi-settings' );
+        $settings_label = __( 'Settings', 'wp-external-featured-image' );
+        $settings_link  = sprintf( '<a href="%s">%s</a>', esc_url( $url ), esc_html( $settings_label ) );
+
+        array_unshift( $links, $settings_link );
+
+        return $links;
     }
 
     /**

--- a/wp-external-featured-image.php
+++ b/wp-external-featured-image.php
@@ -1,12 +1,15 @@
 <?php
 /**
  * Plugin Name: WP External Featured Image
+ * Plugin URI: https://github.com/radialmonster/wp-external-featured-image
  * Description: Use external or Flickr-hosted images as featured images, complete with social meta tags.
  * Version: 1.0.0
- * Author: Your Company
+ * Author: RadialMonster
  * Text Domain: wp-external-featured-image
  * Requires at least: 6.2
  * Requires PHP: 8.0
+ * GitHub Plugin URI: radialmonster/wp-external-featured-image
+ * Primary Branch: main
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
## Summary
- add plugin and GitHub URIs to the plugin header for update integrations
- register a plugin action link that surfaces a shortcut to the settings screen in the plugins list

## Testing
- php -l wp-external-featured-image.php
- php -l includes/class-xefi-plugin.php

------
https://chatgpt.com/codex/tasks/task_e_68e33ae19ea0832397fd6a967ccbedf9